### PR TITLE
Fix: custom username/passwords are ignored

### DIFF
--- a/dragon_rest/dragons.py
+++ b/dragon_rest/dragons.py
@@ -119,7 +119,7 @@ class DragonAPI(object):
         response = requests.post(
             parse.urljoin(self.base_url, '/api/auth'),
             timeout=self.timeout,
-            data={'username': self.username, 'password: self.password})
+            data={'username': self.username, 'password': self.password})
         response.raise_for_status()
         json = response.json()
         self.jwt = json['jwt']

--- a/dragon_rest/dragons.py
+++ b/dragon_rest/dragons.py
@@ -119,7 +119,7 @@ class DragonAPI(object):
         response = requests.post(
             parse.urljoin(self.base_url, '/api/auth'),
             timeout=self.timeout,
-            data={'username': 'admin', 'password': 'dragonadmin'})
+            data={'username': self.username, 'password: self.password})
         response.raise_for_status()
         json = response.json()
         self.jwt = json['jwt']


### PR DESCRIPTION
Authentication username and password are hardcoded. Use username/password from api instance attributes instead.